### PR TITLE
excel playerlink fix

### DIFF
--- a/DamageMeter.Core/ExcelExport.cs
+++ b/DamageMeter.Core/ExcelExport.cs
@@ -260,6 +260,14 @@ namespace DamageMeter
                     ws.Cells[1, 1, j, 8].Style.VerticalAlignment = ExcelVerticalAlignment.Center;
                     ws.Cells[1, 1, j, 8].Style.HorizontalAlignment = ExcelHorizontalAlignment.Center;
                     ws.PrinterSettings.FitToPage = true;
+
+                    // I don't know why, but sometimes column height setting is lost.
+                    for (int x = 1; x < j; ++x)
+                    {
+                        ws.Row(x).CustomHeight = true;
+                        ws.Row(x).Height = 30;
+                    }
+
                     ws.View.TabSelected = true;
                     details.Hidden = eWorkSheetHidden.Hidden;
                     package.Workbook.Properties.Title = Boss.Name;
@@ -647,7 +655,16 @@ namespace DamageMeter
             ws.Cells[1, 1, j, 10].Style.VerticalAlignment = ExcelVerticalAlignment.Center;
             ws.Cells[1, 1, j, 10].Style.HorizontalAlignment = ExcelHorizontalAlignment.Center;
             ws.PrinterSettings.FitToPage = true;
-            return new ExcelHyperLink($"{user.playerServer}_{user.playerName}!A1", $"{user.playerServer}: {user.playerName}");
+
+            // I don't know why, but sometimes column height setting is lost.
+            for (int x = 1; x<j; ++x)
+            {
+                ws.Row(x).CustomHeight = true;
+                ws.Row(x).Height = 30;
+            }
+
+            // If sheet name contains space character, name should be enclosed in single quotes.
+            return new ExcelHyperLink($"'{user.playerServer}_{user.playerName}'!A1", $"{user.playerServer}: {user.playerName}");
         }
 
     }


### PR DESCRIPTION
Hi~

I'm making Korean version.

1. Player link is not working when sheet name contains **space** character.
    Sheet name should be enclosed in single quotes.

2. I don't know why, but sometimes column height setting is lost.
   I'm not sure whether this problem only occurs in the Korean version excel.


Regards, viva aman.