### PR TITLE
Assemblies custom path in config

### DIFF
--- a/DamageMeter.UI/App.config
+++ b/DamageMeter.UI/App.config
@@ -22,6 +22,7 @@
 
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <probing privatePath="dlls\" />
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />


### PR DESCRIPTION
Allow cleanup ShinraMeter main folder from unsorted assemblies . Binary works with assemblies in default location or dlls in _dlls_ folder after change.  All assemblies can be moved manually or with new script after compilation.
**Result:**
_- Main folder:_
```
resources\
dlls\
ShinraMeter.exe.config
ShinraMeter.exe
readme.txt
Randomizer.exe.config
Randomizer.exe
error.log
Autoupdate.exe.config
Autoupdate.exe
add_firewall_exception.bat
```
- _dlls folder_ 
```
zh-TW\
zh-Hans\
zh-CN\
x86\
x64\
<...>
DamageMeter.Sniffing.dll
DamageMeter.dll.config
DamageMeter.D3D9Render.dll
DamageMeter.dll
```