### PR TITLE
Add region localization in discord presence details.

### DIFF
--- a/DamageMeter.Core/RichPresence.cs
+++ b/DamageMeter.Core/RichPresence.cs
@@ -111,7 +111,7 @@ namespace Tera.RichPresence
             Assets = new Assets
             {
                 LargeImageKey = (ShowLocation ? BasicTeraData.Instance.MapData.GetImageName(_location) : null) ?? DefaultImage,
-                LargeImageText = _location == null || !ShowLocation ? null : BasicTeraData.Instance.MapData.GetFullName(_location),
+                LargeImageText = _location == null || !ShowLocation ? null : BasicTeraData.Instance.MapData.GetFullName(_location) + " (" + PacketProcessor.Instance.Server.Region + ")",
                 SmallImageKey = ShowCharacter  && _me != null ? $"class_{_me.RaceGenderClass.Class.ToString().ToLower()}" : null, 
                 SmallImageText = ShowCharacter && _me != null ? $"{LP.RpLevel} {_me.Level} {_me.Name} ({_me.Server})" : null,
             }


### PR DESCRIPTION
Hello,

Discord presence details image text have the same description for EN, NA and SEA.  Adding region in presence details could lead to new functionalities for all discord bots using discord presence information.

I've created my own Battleground Discord Bot, and adding this would allow me to add more functionalities to it.


